### PR TITLE
More work on request duration metrics

### DIFF
--- a/networking_arista/ml2/arista_sec_gp.py
+++ b/networking_arista/ml2/arista_sec_gp.py
@@ -241,6 +241,19 @@ class AristaSwitchRPCMixin(object):
             'networking.arista.apicall_http_duration_seconds',
             r.elapsed.total_seconds(), tags=tags)
 
+        # look for response timings in API json response
+        try:
+            responses = r.json()
+            exec_duration = 0
+            for response in responses['result']:
+                exec_duration += response['_meta']['execDuration']
+
+            self._statsd.histogram(
+                'networking.arista.apicall_exec_duration_seconds',
+                exec_duration, tags=tags)
+        except Exception:
+            pass
+
     def _get_interface_membership(self, server, ports):
         ifm = self._INTERFACE_MEMBERSHIP[server]
         missing = []

--- a/networking_arista/ml2/arista_sec_gp.py
+++ b/networking_arista/ml2/arista_sec_gp.py
@@ -238,7 +238,7 @@ class AristaSwitchRPCMixin(object):
             'http_status_code:{}'.format(r.status_code),
         ]
         self._statsd.histogram(
-            'networking.arista.hook.apicall_duration_seconds',
+            'networking.arista.apicall_http_duration_seconds',
             r.elapsed.total_seconds(), tags=tags)
 
     def _get_interface_membership(self, server, ports):


### PR DESCRIPTION
A metric reported by the Arista API is now send to statsd, too, and can then be used to compare it to the http request time. The apicall-duration metric was also renamed so it can be distinguished better from the Arista API metric.