### PR TITLE
Arista rules icmp handling and hostbit clearing

### DIFF
--- a/networking_arista/ml2/arista_sec_gp.py
+++ b/networking_arista/ml2/arista_sec_gp.py
@@ -979,13 +979,21 @@ class AristaSecGroupSwitchDriver(AristaSwitchRPCMixin):
                     [str(port) for port in
                      acl['ruleFilter'][dir + 'Port']['ports']]))
 
+        flags = ''
+        if acl['ruleFilter']['tcpFlags']:
+            flags = ' syn'
+        elif acl['ruleFilter']['protocol'] == 1 and (
+                acl['ruleFilter']['icmp']['code'] not in (0, 65535) or
+                acl['ruleFilter']['icmp']['type'] not in (0, 65535)):
+            flags = ' {code} {type}'.format(**acl['ruleFilter']['icmp'])
+
         prop = {
             'action': acl['action'],
             'protocol': self._protocol_table[
                 acl['ruleFilter']['protocol']].lower(),
             'src': ips['src'],
             'dst': ips['dst'],
-            'flags': ' syn' if acl['ruleFilter']['tcpFlags'] else ''
+            'flags': flags,
         }
         return "{action} {protocol} {src} {dst}{flags}".format(**prop)
 

--- a/networking_arista/tests/unit/ml2/test_arista_sec_gp.py
+++ b/networking_arista/tests/unit/ml2/test_arista_sec_gp.py
@@ -388,6 +388,19 @@ class AristaSecGroupSwitchDriverTest(testlib_api.SqlTestCase):
                  'sequenceNumber': 10,
                  'text': 'permit tcp host 1.2.3.4 range telnet 42 any syn'}
             ),
+            (
+                'permit icmp 10.180.50.0/22 any 22 22',
+                {'action': 'permit',
+                 'ruleFilter': {'destination': {'ip': '0.0.0.0', 'mask': 0},
+                  'dstPort': {'maxPorts': 10, 'oper': 'any', 'ports': []},
+                  'icmp': {'code': 22, 'type': 22},
+                  'protocol': 1,
+                  'source': {'ip': '10.180.50.0', 'mask': 4294966272},
+                  'srcPort': {'maxPorts': 10, 'oper': 'any', 'ports': []},
+                  'tcpFlags': 0},
+                 'sequenceNumber': 320,
+                 'text': 'permit icmp 10.180.48.0/22 any 22 22'},
+            ),
         ]
 
         for driver_rule, switch_rule in rules:


### PR DESCRIPTION
ICMP flags were not properly understood, also rule comparison does not work when the security group in Openstack has hostbits set (but does after we clear them).