### PR TITLE
Prevent loopingcalls to run in multiple processes

### DIFF
--- a/networking_arista/ml2/arista_sync.py
+++ b/networking_arista/ml2/arista_sync.py
@@ -50,12 +50,20 @@ class SyncService(object):
         self._member_id = None
         self._setup_coordination()
 
+    @staticmethod
+    def gen_member_id():
+        return six.binary_type(
+            "{}({})".format(cfg.CONF.host, os.getpid()).encode('ascii'))
+
+    def is_member_id_valid(self):
+        """Check if this sync service still lives on the original process"""
+        return self._member_id == self.gen_member_id()
+
     def _setup_coordination(self):
         if not cfg.CONF.ml2_arista.coordinator_url:
             return
 
-        self._member_id = six.binary_type(
-            "{}({})".format(cfg.CONF.host, os.getpid()).encode('ascii'))
+        self._member_id = self.gen_member_id()
 
         coordinator = coordination.get_coordinator(
             cfg.CONF.ml2_arista.coordinator_url,

--- a/networking_arista/ml2/mechanism_arista.py
+++ b/networking_arista/ml2/mechanism_arista.py
@@ -1009,9 +1009,21 @@ class AristaDriver(api.MechanismDriver):
         return hostname if fqdns_used else hostname.split('.')[0]
 
     def _save_switch_configs_thread(self):
+        if not self.sync_service.is_member_id_valid():
+            LOG.info("Switch config save thread was started unnecessarily "
+                     "in this process, stopping it")
+            self._config_save_loop.stop()
+            return
+
         self.sync_service.save_switch_configs()
 
     def _synchronization_thread(self):
+        if not self.sync_service.is_member_id_valid():
+            LOG.info("Synchronization thread was started unnecessarily "
+                     "in this process, stopping it")
+            self.timer.stop()
+            return
+
         self.sync_service.do_synchronize()
 
     def stop_synchronization_thread(self):


### PR DESCRIPTION
The Arista mechanism driver has multiple loopingcalls taking care of
syncing security groups and saving switch config. When neutron forks off
its workers it seems these looping calls are present in all workers, but
are only running in one and paused in the others. Due to some unknown
cause these sleeping threads might somehow get resumed after an unknown
amount of time (hours, days, never) and then we are in a situation where
every single worker on the active driver host is hammering the API,
essentially bringing down the switch API with this.

For the synchronization we generate a member id which includes the PID.
For the forked processes this PID will be different, resulting in a
different generated id for the coordinator. To prevent these threads
from running we now check if the coordinator id is differing from what
the coordinator was set up with. If it differs we shut down the thread.

Suspected causes for this are some sort of failure inside the Tooz
coordinator or something causing a ToozError (not a
ToozConnectionError). Other exceptions might be able to trigger this as
well, but could not be reproduced yet.