### PR TITLE
Fix multi-sg naming with python3

### DIFF
--- a/networking_arista/ml2/arista_sec_gp.py
+++ b/networking_arista/ml2/arista_sec_gp.py
@@ -1439,7 +1439,7 @@ class AristaSecGroupSwitchDriver(AristaSwitchRPCMixin):
         else:
             s = sha1()
             for n in sorted(name):
-                s.update(n)
+                s.update(n.encode())
             return s.hexdigest()
 
     @staticmethod

--- a/networking_arista/tests/unit/ml2/test_arista_sec_gp.py
+++ b/networking_arista/tests/unit/ml2/test_arista_sec_gp.py
@@ -1109,3 +1109,12 @@ class AristaSecGroupSwitchDriverTest(testlib_api.SqlTestCase):
 
         ifs = self.drv._get_mlag_pc_members_from_iface(server, "Ethernet19/3")
         self.assertEqual(expected, set(ifs))
+
+    def test_security_group_naming(self):
+        names = [
+            "af7c4ba1-3bbb-465f-845d-40ce0004064c",
+            "6baa1ff1-1f59-43cf-971e-95bcb93c15d0"
+        ]
+        expected = "a8cc23faa69ed81bb9734b681dd0052a4d440ef7"
+        result = self.drv._security_group_name(names)
+        self.assertEqual(expected, result)


### PR DESCRIPTION
In python3 hasing needs to happen on byte-objects, not strings.
Therefore we need to encode the name before feeding it to the hash
function.