### PR TITLE
Fix db deadlock in _cleanup_db() by adding retry annotation

### DIFF
--- a/networking_arista/ml2/mechanism_arista.py
+++ b/networking_arista/ml2/mechanism_arista.py
@@ -28,6 +28,7 @@ from neutron_lib.api.definitions import portbindings
 from neutron_lib import constants as n_const
 from neutron_lib import constants as p_const
 from neutron_lib.context import get_admin_context
+from neutron_lib.db import api as db_api
 from neutron_lib.plugins.ml2 import api
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -1032,6 +1033,7 @@ class AristaDriver(api.MechanismDriver):
             self.timer = None
 
     # @enginefacade.writer
+    @db_api.retry_db_errors
     def _cleanup_db(self, context):
         """Clean up any unnecessary entries in our DB."""
         session = context.session


### PR DESCRIPTION
When starting multiple neutron-server instances at ones, the complex query caused
by _cleanup_db is holding a lock for quite a long time, causing other instances to fail on startup
since the query is a mandatory step in the initalization.

This patch first adds a db retry annotation that will retry in case of a detected deadlock.