### PR TITLE
Run db_cleanup in seperate greenthread after initialization

### DIFF
--- a/networking_arista/ml2/mechanism_arista.py
+++ b/networking_arista/ml2/mechanism_arista.py
@@ -18,6 +18,8 @@ if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
     import eventlet
 
     eventlet.monkey_patch()
+import random
+from eventlet import greenthread
 
 from neutron.common import config as common_config
 
@@ -104,7 +106,7 @@ class AristaDriver(api.MechanismDriver):
             self.rpc.check_supported_features()
 
         context = get_admin_context()
-        self._cleanup_db(context)
+        greenthread.spawn_after(random.randint(0, 10), self._cleanup_db, context)
         # Registering with EOS updates self.rpc.region_updated_time. Clear it
         # to force an initial sync
         self.rpc.clear_region_updated_time()

--- a/networking_arista/tests/unit/ml2/test_arista_mechanism_driver.py
+++ b/networking_arista/tests/unit/ml2/test_arista_mechanism_driver.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import socket
 
+import eventlet
 import mock
 import neutron_lib.db.api as db
 
@@ -1803,8 +1804,9 @@ class RealNetStorageAristaDriverTestCase(testlib_api.SqlTestCase):
         db_lib.remember_network_segment(context, 't3', 'n3', 30,
                                         'segment_id_30')
 
-        # Initialize the driver which should clean up the extra networks
+        # Initialize the driver which should clean up the extra networks, which should be done after 10 secs
         self.drv.initialize()
+        eventlet.sleep(10)
 
         adb_networks = db_lib.get_networks(context, project_id='any')
 


### PR DESCRIPTION
_db_cleanup uses a complex subquery. If many arista-hosted baremetals are bound,
this causes large delays in neutron-server startup.

This patch runs the cleanup method after the initialzation as a greenthread.