### PR TITLE
Remove broken config validation for nocvx

### DIFF
--- a/networking_arista/ml2/rpc/arista_nocvx.py
+++ b/networking_arista/ml2/rpc/arista_nocvx.py
@@ -47,6 +47,11 @@ class AristaRPCWrapperNoCvx(AristaRPCWrapperBase,
     def check_cvx_availability(self):
         return True
 
+    def _validate_config(self):
+        # Override config validation method from AristaRPCWrapperBase
+        # it only validates eapi variables not used by this class
+        pass
+
     def plug_port_into_network(self, device_id, host_id, neutron_port_id,
                                net_id, tenant_id, port_name, device_owner,
                                sg, orig_sg, vnic_type, segments=None,


### PR DESCRIPTION
NoCVX does not need eapi_host or eapi_username to be set, but there was
still code present checking for the presence of these two values. As
NoCVX is not using these two variables, we don't require them to be
present and can just override the checking method with a NOOP method.