### PR TITLE
Don't deny network deletion on still provisioned ports

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [3.6]

--- a/networking_arista/ml2/mechanism_arista.py
+++ b/networking_arista/ml2/mechanism_arista.py
@@ -220,13 +220,12 @@ class AristaDriver(api.MechanismDriver):
                                          network_id):
             if db_lib.are_ports_attached_to_network(plugin_context,
                                                     network_id):
-                LOG.info(_LI('Network %s can not be deleted as it '
-                             'has ports attached to it'), network_id)
-                raise ml2_exc.MechanismDriverError(
-                    method='delete_network_precommit')
-            else:
-                db_lib.forget_network_segment(plugin_context,
-                                              tenant_id, network_id)
+                LOG.info('Network %s has ports attached to it, so we now show '
+                         'that we don\'t care about this and clean the '
+                         'database', network_id)
+                db_lib.forget_all_ports_for_network(plugin_context, network_id)
+            db_lib.forget_network_segment(plugin_context,
+                                          tenant_id, network_id)
 
     def delete_network_postcommit(self, context):
         """Send network delete request to Arista HW."""

--- a/networking_arista/tests/unit/ml2/test_mechanism_arista.py
+++ b/networking_arista/tests/unit/ml2/test_mechanism_arista.py
@@ -237,18 +237,17 @@ class AristaDriverTestCase(testlib_api.SqlTestCase):
         mechanism_arista.db_lib.num_vms_provisioned.return_value = 0
         mechanism_arista.db_lib.are_ports_attached_to_network.return_value = (
             True)
-        try:
-            self.drv.delete_network_precommit(network_context)
-        except Exception:
-            # exception is expeted in this case - as network is not
-            # deleted in this case and exception is raised
-            pass
+        self.drv.delete_network_precommit(network_context)
 
         expected_calls = [
             mock.call.is_network_provisioned(network_context._plugin_context,
                                              tenant_id, network_id),
             mock.call.are_ports_attached_to_network(
                 network_context._plugin_context, network_id),
+            mock.call.forget_all_ports_for_network(
+                network_context._plugin_context, network_id),
+            mock.call.forget_network_segment(network_context._plugin_context,
+                                             tenant_id, network_id),
         ]
 
         mechanism_arista.db_lib.assert_has_calls(expected_calls)


### PR DESCRIPTION
Sometimes networking-arista puts ports in its DB that it shouldn't have, as they never where provisioned there. We have not spent much time in figuring out why that is due to time limitations. All we want this driver to do currently is configure the baremetal Arista switches that we have and to NOT block network deletions.

Therefore I am now removing the part that raises an error in the delete_network_precommit() hook and replace it by a piece of code that just deletes all remaining ports for the network in the Arista shadow db. Note that we only touch the Arista shadow tables here, which are only used by the driver (and even there with nocvx I'm not entirely sure that they are used by us). Upstream has dropped them a long time ago, but we didn't spent the time to actually clean up the whole driver.