### PR TITLE
Promote unknown server to log level error

### DIFF
--- a/networking_arista/ml2/rpc/arista_nocvx.py
+++ b/networking_arista/ml2/rpc/arista_nocvx.py
@@ -69,7 +69,7 @@ class AristaRPCWrapperNoCvx(AristaRPCWrapperBase,
             server = self._get_server(switch_info=binding['switch_info'],
                                       switch_id=binding['switch_id'])
             if server is None:
-                LOG.warning("Unknown server for port-binding %s", binding)
+                LOG.error("Unknown server for port-binding %s", binding)
                 continue
 
             port_id = binding['port_id']


### PR DESCRIPTION
When we don't find a switch by mac it's probably going to be a problem at some point, so let's raise the log level to error to make it more visible.