### PR TITLE
Prevent MemberAlreadyExist when pod is being restarted

### DIFF
--- a/networking_arista/ml2/arista_sync.py
+++ b/networking_arista/ml2/arista_sync.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import os
 import six
 
 from neutron_lib import context as neutron_context
 from oslo_config import cfg
 from oslo_log import log as logging
+import psutil
 from tooz import coordination
 
 from networking_arista._i18n import _
@@ -52,8 +54,10 @@ class SyncService(object):
 
     @staticmethod
     def gen_member_id():
-        return six.binary_type(
-            "{}({})".format(cfg.CONF.host, os.getpid()).encode('ascii'))
+        start_time = psutil.Process(os.getpid()).create_time()
+        start_time = datetime.utcfromtimestamp(start_time).isoformat()
+        member_id = f'{cfg.CONF.host}-({os.getpid()})-{start_time}'
+        return six.binary_type(member_id.encode('ascii'))
 
     def is_member_id_valid(self):
         """Check if this sync service still lives on the original process"""


### PR DESCRIPTION
If the pod is being restarted this will often lead to it crashlooping.
That is, as the we generate the coordinator member_id on the PID and the
hostname. Yet, that will be the same when the pod is being restarted. As
long as the interval between restarts is shorter than
`membership_timeout` a restart will be unsuccessful as the old member
has not timed out yet.
